### PR TITLE
Fix scoreboard operations running off main thread

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/Main.java
+++ b/src/main/java/com/booksaw/betterTeams/Main.java
@@ -386,7 +386,7 @@ public class Main extends JavaPlugin {
 
 				teamManagement = new MCTeamManagement(type);
 
-				Bukkit.getScheduler().runTaskAsynchronously(this, () -> teamManagement.displayBelowNameForAll());
+                                Bukkit.getScheduler().runTask(this, () -> teamManagement.displayBelowNameForAll());
 				getServer().getPluginManager().registerEvents(teamManagement, this);
 				Main.plugin.getLogger().info("teamManagement declared: " + teamManagement);
 			}

--- a/src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java
@@ -37,14 +37,24 @@ public class MCTeamManagement implements Listener {
 
 	}
 
-	public void displayBelowNameForAll() {
-		for (Player p : Bukkit.getOnlinePlayers()) {
-			displayBelowName(p);
-		}
-	}
+        public void displayBelowNameForAll() {
+                if (!Bukkit.isPrimaryThread()) {
+                        Bukkit.getScheduler().runTask(Main.plugin, this::displayBelowNameForAll);
+                        return;
+                }
 
-	public void displayBelowName(Player player) {
-		player.setScoreboard(board);
+                for (Player p : Bukkit.getOnlinePlayers()) {
+                        displayBelowName(p);
+                }
+        }
+
+        public void displayBelowName(Player player) {
+                if (!Bukkit.isPrimaryThread()) {
+                        Bukkit.getScheduler().runTask(Main.plugin, () -> displayBelowName(player));
+                        return;
+                }
+
+                player.setScoreboard(board);
 
 		Team team = Team.getTeam(player);
 		if (team == null) {
@@ -131,9 +141,9 @@ public class MCTeamManagement implements Listener {
 	}
 
 	@EventHandler
-	public void playerJoinEvent(PlayerJoinEvent e) {
-		Bukkit.getScheduler().runTaskAsynchronously(Main.plugin, () -> displayBelowName(e.getPlayer()));
-	}
+        public void playerJoinEvent(PlayerJoinEvent e) {
+                Bukkit.getScheduler().runTask(Main.plugin, () -> displayBelowName(e.getPlayer()));
+        }
 
 	public void setupTeam(org.bukkit.scoreboard.Team team, String teamName) {
 		// setting team name

--- a/src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java
@@ -37,24 +37,32 @@ public class MCTeamManagement implements Listener {
 
 	}
 
-        public void displayBelowNameForAll() {
-                if (!Bukkit.isPrimaryThread()) {
-                        Bukkit.getScheduler().runTask(Main.plugin, this::displayBelowNameForAll);
-                        return;
-                }
+	private void runSync(Runnable task) {
+	if (Bukkit.isPrimaryThread()) {
+	task.run();
+	} else {
+	Bukkit.getScheduler().runTask(Main.plugin, task);
+	}
+	}
 
-                for (Player p : Bukkit.getOnlinePlayers()) {
-                        displayBelowName(p);
-                }
-        }
+	public void displayBelowNameForAll() {
+	runSync(() -> {
+	for (Player p : Bukkit.getOnlinePlayers()) {
+	displayBelowNameSync(p);
+	}
+	});
+	}
 
-        public void displayBelowName(Player player) {
-                if (!Bukkit.isPrimaryThread()) {
-                        Bukkit.getScheduler().runTask(Main.plugin, () -> displayBelowName(player));
-                        return;
-                }
+	public void displayBelowName(Player player) {
+	if (player == null) {
+	return;
+	}
 
-                player.setScoreboard(board);
+	runSync(() -> displayBelowNameSync(player));
+	}
+
+	private void displayBelowNameSync(Player player) {
+	player.setScoreboard(board);
 
 		Team team = Team.getTeam(player);
 		if (team == null) {
@@ -141,9 +149,9 @@ public class MCTeamManagement implements Listener {
 	}
 
 	@EventHandler
-        public void playerJoinEvent(PlayerJoinEvent e) {
-                Bukkit.getScheduler().runTask(Main.plugin, () -> displayBelowName(e.getPlayer()));
-        }
+	public void playerJoinEvent(PlayerJoinEvent e) {
+	        Bukkit.getScheduler().runTask(Main.plugin, () -> displayBelowName(e.getPlayer()));
+	}
 
 	public void setupTeam(org.bukkit.scoreboard.Team team, String teamName) {
 		// setting team name


### PR DESCRIPTION
### **User description**
## Summary
- ensure below-name scoreboard updates run on the main thread
- replace async scheduling in `setupListeners`
- add thread checks inside `MCTeamManagement`

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686ae8b77e0883219566daa9d93ecd94


___

### **PR Type**
Bug fix


___

### **Description**
- Fix scoreboard operations running on main thread

- Add thread safety checks in `MCTeamManagement`

- Replace async scheduling with sync scheduling

- Ensure scoreboard updates execute on primary thread


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Async Scheduler"] --> B["Main Thread Check"]
  B --> C["Scoreboard Operations"]
  C --> D["Player Display Updates"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Main.java</strong><dd><code>Switch to synchronous task scheduling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/booksaw/betterTeams/Main.java

<li>Replace <code>runTaskAsynchronously</code> with <code>runTask</code> for scoreboard <br>initialization


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/BetterTeams/pull/1/files#diff-43bb22b291b609f5bfbbe7d93579a156c17d1b03a60c35fce74fe21bd9b44988">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MCTeamManagement.java</strong><dd><code>Add thread safety for scoreboard operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java

<li>Add thread safety checks using <code>Bukkit.isPrimaryThread()</code><br> <li> Ensure scoreboard operations run on main thread<br> <li> Replace async scheduling with sync scheduling in event handler


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/BetterTeams/pull/1/files#diff-a678d295d436e659f05a4c11e822abb134915d19c36ae6fd2ff828cce78613d2">+20/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scoreboard updates to ensure they run on the main server thread, preventing potential issues with asynchronous execution during player events and scoreboard displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->